### PR TITLE
feat: thanos handling replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,11 @@ Create a `values.yaml` file based on the provided `values.yaml.example`.
 You can check all option available at `./thanos/values.yaml`, as well as
 on the official `prometheus-operator` and `grafana` Helm charts.
 
-#### 4. Install
+#### 4. Install/Upgrade
 
 ```sh
-helm install --namespace thanos --name thanos carlos/thanos -f values.yaml \
-  --set-file objectStore=thanos-storage-config.yaml
-```
-
-##### 4.1 Upgrade when needed
-
-```sh
-helm upgrade --namespace thanos thanos carlos/thanos -f values.yaml \
+helm upgrade --install --namespace thanos thanos carlos/thanos \
+  -f values.yaml \
   --set-file objectStore=thanos-storage-config.yaml
 ```
 
@@ -191,7 +185,7 @@ helm upgrade --install --namespace thanos thanos ./thanos \
   - [ ] improve config
 - [x] service discovery inside the cluster
 - [x] service discovery across clusters
-- [ ] dynamic prometheus replica label for deduplication
+- [x] dynamic prometheus replica label for deduplication - see [#2591](https://github.com/coreos/prometheus-operator/pull/2591)
 - [x] recommended rules for thanos components
 - [x] recommended dashboards for thanos components
 - [x] thanos as datasource in grafana

--- a/examples/values1.yaml
+++ b/examples/values1.yaml
@@ -3,8 +3,7 @@ prometheus-operator:
     prometheusSpec:
       replicas: 2
       externalLabels:
-        region: local
-        replica: a
+        region: thanos1
       thanos:
         objectStorageConfig:
           # this should be ${releaseName}-thanos-object-store

--- a/examples/values2.yaml
+++ b/examples/values2.yaml
@@ -17,8 +17,7 @@ prometheus-operator:
     prometheusSpec:
       replicas: 2
       externalLabels:
-        region: local2
-        replica: a
+        region: thanos2
       thanos:
         objectStorageConfig:
           # this should be ${releaseName}-thanos-object-store

--- a/examples/values3.yaml
+++ b/examples/values3.yaml
@@ -4,7 +4,6 @@ prometheus-operator:
       replicas: 2
       externalLabels:
         region: local
-        replica: a
       thanos:
         objectStorageConfig:
           # this should be ${releaseName}-thanos-object-store

--- a/thanos/requirements.lock
+++ b/thanos/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus-operator
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.10.4
-digest: sha256:402ba365513be344603d89905cf53660755421a88435d086bdc89a53b8671558
-generated: "2019-05-27T23:24:22.723495-03:00"
+  version: 5.12.3
+digest: sha256:25b343e0c99e6f70927508e108e5cb826d5cdcb0a1d1246b1b0f379f0b1134ac
+generated: "2019-06-15T13:12:52.877919-03:00"

--- a/thanos/requirements.yaml
+++ b/thanos/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 
   - name: prometheus-operator
-    version: 5.10.*
+    version: 5.12.*
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -34,10 +34,6 @@ prometheus-operator:
         enabled: true
         label: grafana_dashboard
 
-  prometheusOperator:
-    image:
-      tag: v0.30.1
-
 image:
   repository: improbable/thanos
   tag: v0.4.0
@@ -99,7 +95,7 @@ query:
   stores:
     - dnssrv+_grpc._tcp.thanos-store-grpc.thanos.svc.cluster.local
     - dnssrv+_grpc._tcp.thanos-sidecar-grpc.thanos.svc.cluster.local
-  queryReplicaLabel: replica
+  queryReplicaLabel: prometheus_replica
 
   # cert, key and ca are base64 encoded strings
   tlsClient:

--- a/values.yaml.example
+++ b/values.yaml.example
@@ -13,7 +13,6 @@ prometheus-operator:
 query:
   replicaCount: 2
   logLevel: info
-  queryReplicaLabel: replica
 
 store:
   replicaCount: 2

--- a/values.yaml.example
+++ b/values.yaml.example
@@ -4,7 +4,6 @@ prometheus-operator:
       replicas: 2
       externalLabels:
         region: local
-        replica: a
       thanos:
         objectStorageConfig:
           # this should be ${releaseName}-thanos-object-store
@@ -14,6 +13,7 @@ prometheus-operator:
 query:
   replicaCount: 2
   logLevel: info
+  queryReplicaLabel: replica
 
 store:
   replicaCount: 2


### PR DESCRIPTION
thanos adds by default a `prometheus_replica` label, just need to use it as replica label on querier.


![image](https://user-images.githubusercontent.com/245435/59553898-392ffa00-8f72-11e9-9da2-5b23555107fd.png)


![image](https://user-images.githubusercontent.com/245435/59553896-333a1900-8f72-11e9-83f0-fcfa7fa87c80.png)
