### PR TITLE
fix: replicacount vs replicas

### DIFF
--- a/examples/values1.yaml
+++ b/examples/values1.yaml
@@ -11,7 +11,7 @@ prometheus-operator:
           key: store.yaml
 
 query:
-  replicaCount: 2
+  replicas: 2
   logLevel: info
   stores:
     - dnssrv+_grpc._tcp.thanos1-store-grpc.thanos1.svc.cluster.local
@@ -19,4 +19,4 @@ query:
     - dnssrv+_grpc._tcp.thanos2-query-grpc.thanos2.svc.cluster.local
 
 store:
-  replicaCount: 2
+  replicas: 2

--- a/examples/values2.yaml
+++ b/examples/values2.yaml
@@ -25,7 +25,7 @@ prometheus-operator:
           key: store.yaml
 
 query:
-  replicaCount: 2
+  replicas: 2
   stores:
     - dnssrv+_grpc._tcp.thanos2-sidecar-grpc.thanos2.svc.cluster.local
 

--- a/examples/values3.yaml
+++ b/examples/values3.yaml
@@ -25,8 +25,8 @@ prometheus-operator:
       # GF_AUTH_OAUTH_AUTO_LOGIN: 'true'
 
 query:
-  replicaCount: 2
+  replicas: 2
   logLevel: info
 
 store:
-  replicaCount: 2
+  replicas: 2

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: compact
 spec:
-  replicas: {{ .Values.compact.replicaCount }}
+  replicas: {{ .Values.compact.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: query
 spec:
-  replicas: {{ .Values.query.replicaCount }}
+  replicas: {{ .Values.query.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: store
 spec:
-  replicas: {{ .Values.store.replicaCount }}
+  replicas: {{ .Values.store.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/values.yaml.example
+++ b/values.yaml.example
@@ -11,8 +11,8 @@ prometheus-operator:
           key: store.yaml
 
 query:
-  replicaCount: 2
+  replicas: 2
   logLevel: info
 
 store:
-  replicaCount: 2
+  replicas: 2


### PR DESCRIPTION
every other helm chart uses `replicas`... standarize maybe?