### PR TITLE
feat: one ingress for each prometheus replica

### DIFF
--- a/thanos/templates/sidecar-ingress-grpc.yaml
+++ b/thanos/templates/sidecar-ingress-grpc.yaml
@@ -1,25 +1,37 @@
-{{- if .Values.sidecar.ingress.host }}
+{{- if and .Values.sidecar.ingress.basename .Values.sidecar.ingress.domain }}
+{{- $count := (index .Values "prometheus-operator" "prometheus" "prometheusSpec" "replicas" | int) }}
+{{- $fullname := include "thanos.fullname" . }}
+{{- $name := include "thanos.name" . }}
+{{- $chart := include "thanos.chart" . }}
+{{- $releaseName := .Release.Name }}
+{{- $service := .Release.Service }}
+{{- $annotations := .Values.sidecar.ingress.annotations }}
+{{- $domain := .Values.sidecar.ingress.domain }}
+{{- $basename := .Values.sidecar.ingress.basename }}
+{{- range $replica := until $count }}
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ include "thanos.fullname" . }}-sidecar
-{{- if .Values.sidecar.ingress.annotations }}
+  name: {{ $fullname }}-sidecar-{{ $replica }}
+{{- with $annotations }}
   annotations:
-{{ toYaml .Values.sidecar.ingress.annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "thanos.name" . }}
-    helm.sh/chart: {{ include "thanos.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ $name }}
+    helm.sh/chart: {{ $chart }}
+    app.kubernetes.io/instance: {{ $releaseName }}
+    app.kubernetes.io/managed-by: {{ $service }}
     app.kubernetes.io/component: sidecar
 spec:
   rules:
-  - host: {{ .Values.sidecar.ingress.host | quote }}
+  - host: "{{ $basename }}-{{ $replica }}.{{ $domain }}"
     http:
       paths:
       - path: /
         backend:
-          serviceName: {{ include "thanos.fullname" . }}-sidecar-grpc
+          serviceName: {{ $fullname }}-sidecar-grpc-{{ $replica }}
           servicePort: 10901
 {{- end -}}
+{{- end }}

--- a/thanos/templates/sidecar-service-grpc.yaml
+++ b/thanos/templates/sidecar-service-grpc.yaml
@@ -1,12 +1,24 @@
+{{- $fullname := include "thanos.fullname" . }}
+{{- $name := include "thanos.name" . }}
+{{- $chart := include "thanos.chart" . }}
+{{- $releaseName := .Release.Name }}
+{{- $service := .Release.Service }}
+{{- $prometheus := printf "%s-prometheus-operator" .Release.Name | trunc 26 | trimSuffix "-" }}
+
+{{- if and .Values.sidecar.ingress.basename .Values.sidecar.ingress.domain }}
+
+{{- $count := (index .Values "prometheus-operator" "prometheus" "prometheusSpec" "replicas" | int) }}
+{{- range $replica := until $count }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "thanos.fullname" . }}-sidecar-grpc
+  name: {{ $fullname }}-sidecar-grpc-{{ $replica }}
   labels:
-    app.kubernetes.io/name: {{ include "thanos.name" . }}
-    helm.sh/chart: {{ include "thanos.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ $name }}
+    helm.sh/chart: {{ $chart }}
+    app.kubernetes.io/instance: {{ $releaseName }}
+    app.kubernetes.io/managed-by: {{ $service }}
     app.kubernetes.io/component: sidecar
 spec:
   type: ClusterIP
@@ -18,5 +30,29 @@ spec:
       name: grpc
   selector:
     app: prometheus
-    # XXX: why prometheus operator cuts at 26?
-    prometheus: "{{- printf "%s-prometheus-operator" .Release.Name | trunc 26 | trimSuffix "-" -}}-prometheus"
+    statefulset.kubernetes.io/pod-name: "prometheus-{{ $prometheus }}-prometheus-{{ $replica }}"
+{{- end }}
+
+{{- else }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-sidecar-grpc
+  labels:
+    app.kubernetes.io/name: {{ $name }}
+    helm.sh/chart: {{ $chart }}
+    app.kubernetes.io/instance: {{ $releaseName }}
+    app.kubernetes.io/managed-by: {{ $service }}
+    app.kubernetes.io/component: sidecar
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 10901
+      protocol: TCP
+      targetPort: grpc
+      name: grpc
+  selector:
+    app: prometheus
+    prometheus: "{{ $prometheus }}-prometheus"
+{{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -167,6 +167,7 @@ sidecar:
     externalTrafficPolicy: ""
 
   ingress:
-    host: ""
+    basename: ""
+    domain: ""
     annotations:
       ingress.kubernetes.io/protocol: h2c


### PR DESCRIPTION
when we have ingress enabled for the sidecar, create one service and one ingress per replica so we can have more reliability/parallelism for queries.

ingress host will be `basename-$idx.domain`.

The multiple ingress will also fix this:

![image](https://user-images.githubusercontent.com/245435/62572019-2a2a4180-b869-11e9-978e-e570cfbfd863.png)

when using TLS, since you'll have multiple DNSs (one for each replica).