### PR TITLE
WIP: Adding receive component

### DIFF
--- a/thanos/templates/receiver-deployment.yaml
+++ b/thanos/templates/receiver-deployment.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.receive.enabled }}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "thanos.fullname" . }}-receive
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: receive
+spec:
+  replicas: {{ .Values.receive.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: receive
+  template:
+    metadata:
+    {{- if .Values.receive.deployment.annotations }}
+      annotations:
+{{ toYaml .Values.receive.deployment.annotations | indent 8 }}
+    {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "thanos.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: receive
+    spec:
+      containers:
+        - name: thanos-receive
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "receive"
+            - "--log.level={{ .Values.receive.logLevel }}"
+            - "--objstore.config-file=/etc/thanos-object-store/store.yaml"
+            - "--tsdb.path=/var/thanos/receive"
+            - "--tsdb.retention=1h"
+          ports:
+            - name: http
+              containerPort: 19291
+            - name: metrics
+              containerPort: 10902
+            - name: grpc
+              containerPort: 10901
+          volumeMounts:
+            - name: data
+              mountPath: /var/thanos/receive
+            - name: object-store
+              mountPath: /etc/thanos-object-store
+          resources:
+{{ toYaml .Values.receive.resources | indent 12 }}
+    {{- with .Values.receive.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.receive.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.receive.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: data
+        - name: object-store
+          secret:
+            secretName: {{ include "thanos.fullname" . }}-thanos-object-store
+{{- end -}}

--- a/thanos/templates/receiver-ingress-http.yaml
+++ b/thanos/templates/receiver-ingress-http.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.receive.enabled }}
+{{- if .Values.receive.httpIngress.host }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "thanos.fullname" . }}-receive-http
+{{- if .Values.receive.httpIngress.annotations }}
+  annotations:
+{{ toYaml .Values.receive.httpIngress.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: receive
+spec:
+  rules:
+  - host: {{ .Values.receive.httpIngress.host | quote }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ include "thanos.fullname" . }}-receive-http
+          servicePort: 19291
+{{- end -}}
+{{- end -}}

--- a/thanos/templates/receiver-poddisruptionbudget.yaml
+++ b/thanos/templates/receiver-poddisruptionbudget.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.receive.enabled .Values.receive.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "thanos.fullname" . }}-receive
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: receive
+spec:
+  {{- if .Values.receive.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.receive.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.receive.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.receive.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: receive
+{{- end -}}

--- a/thanos/templates/receiver-service-grpc.yaml
+++ b/thanos/templates/receiver-service-grpc.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.receive.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thanos.fullname" . }}-receive-grpc
+{{- if .Values.receive.grpcService.annotations }}
+  annotations:
+{{ toYaml .Values.receive.grpcService.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: receive
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 10901
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: receive
+{{- end -}}

--- a/thanos/templates/receiver-service-http.yaml
+++ b/thanos/templates/receiver-service-http.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.receive.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thanos.fullname" . }}-receive-http
+{{- if .Values.receive.httpService.annotations }}
+  annotations:
+{{ toYaml .Values.receive.httpService.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: receive
+spec:
+  type: {{ .Values.receive.httpService.type }}
+  {{- if .Values.receive.httpService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.receive.httpService.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: 19291
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: receive
+{{- end -}}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -147,7 +147,7 @@ query:
 # EXPERIMENTAL COMPONENT
 # Thanos receive configuration
 receive:
-  enabled: true
+  enabled: false
   replicaCount: 1
 
   logLevel: info

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -98,6 +98,7 @@ query:
   stores:
     - dnssrv+_grpc._tcp.thanos-store-grpc.thanos.svc.cluster.local
     - dnssrv+_grpc._tcp.thanos-sidecar-grpc.thanos.svc.cluster.local
+    - dnssrv+_grpc._tcp.thanos-receive-grpc.thanos.svc.cluster.local
   queryReplicaLabel: prometheus_replica
 
   deployment:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -143,6 +143,57 @@ query:
     minAvailable: 1
     maxUnavailable: ""
 
+# EXPERIMENTAL COMPONENT
+# Thanos receive configuration
+receive:
+  enabled: true
+  replicaCount: 1
+
+  logLevel: info
+
+  deployment:
+    annotations: {}
+
+  httpService:
+    type: ClusterIP
+    externalTrafficPolicy: ""
+    annotations: {}
+
+  grpcService:
+    annotations: {}
+
+  httpIngress:
+    host: ""
+    annotations: {}
+
+  grpcIngress:
+    host: ""
+    annotations:
+      ingress.kubernetes.io/protocol: h2c
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
 # Thanos compact configuration
 compact:
   enabled: true


### PR DESCRIPTION
Hi ! 

Thanks for your work !
I would just add the receive component in this Helm chart : https://thanos.io/proposals/201812_thanos-remote-receive.md/

- [x] Receive works,
- [ ] Grafana Dashboard,
- [ ] Prometheus Rules,
- [ ] Review/change default values,
  - [ ] `tsdb.retention` (deployment),
  - [x] `enabled ` (values).

<img width="1278" alt="Capture d’écran 2019-08-19 à 15 39 11" src="https://user-images.githubusercontent.com/15982613/63270086-be4bce00-c297-11e9-96e1-e976b8281605.png">

Do not hesitate to make a feedback :)