### PR TITLE
feat: bump prometheus-operator chart

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: A Helm chart for thanos
 name: thanos
-version: 14.3.0
+version: 14.4.0

--- a/charts/thanos/requirements.lock
+++ b/charts/thanos/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus-operator
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.13.8
-digest: sha256:e68f8d1f67f187bec6f5a11cfbbf51949711053a1d65b932599645ced9b8a3db
-generated: "2020-05-26T17:23:28.598701-03:00"
+  repository: https://charts.helm.sh/stable
+  version: 9.3.2
+digest: sha256:ce9b182cc664b4ebe041427a1257e0fd76c96d96b7d4754276eccb6e30ebc010
+generated: "2021-08-06T14:38:40.827591-03:00"

--- a/charts/thanos/requirements.yaml
+++ b/charts/thanos/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: prometheus-operator
-    version: 8.13.*
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 9.3.2
+    repository: https://charts.helm.sh/stable


### PR DESCRIPTION
As I checked the main change was:

```
Version 9 of the helm chart removes the existing `additionalScrapeConfigsExternal` in favour of `additionalScrapeConfigsSecret`.
```

And it does not set in this chart.. so seems safe to upgrade  